### PR TITLE
Add version flag and better git user info errors

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,10 @@ Increments the version number and tags it. (You will need to push)
 
 ```
 ./git-tag-inc [major] [minor] [patch] [release] [alpha|beta|rc] [test|uat]
+--version
 ```
+
+Use `--version` to display build information and credits.
 
 `--mode arraneous` switches to the legacy naming (patch becomes `release`).
 


### PR DESCRIPTION
## Summary
- add `--version` flag to print build information
- provide clearer error message when git user.name/email is not configured
- include repo and credits in version output
- document `--version` option in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684151296354832f93a395cbec875d30