### PR TITLE
Add print-version-only flag

### DIFF
--- a/cmd/git-tag-inc/main.go
+++ b/cmd/git-tag-inc/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"time"
@@ -16,11 +17,12 @@ import (
 )
 
 var (
-	verbose     = flag.Bool("verbose", false, "Extra output")
-	showVersion = flag.Bool("version", false, "Print version information")
-	dry         = flag.Bool("dry", false, "Dry run")
-	ignore      = flag.Bool("ignore", true, "Ignore uncommitted files")
-	repeating   = flag.Bool("repeating", false, "Allow new tags to repeat a previous")
+	verbose          = flag.Bool("verbose", false, "Extra output")
+	showVersion      = flag.Bool("version", false, "Print version information")
+	dry              = flag.Bool("dry", false, "Dry run")
+	printVersionOnly = flag.Bool("print-version-only", false, "Print next version only")
+	ignore           = flag.Bool("ignore", true, "Ignore uncommitted files")
+	repeating        = flag.Bool("repeating", false, "Allow new tags to repeat a previous")
 	// TODO: consider supporting other naming modes such as "xyzzy",
 	// "hybrid" or "octarine" which some teams use internally.
 	mode = flag.String("mode", "default", "Naming mode: default or arraneous")
@@ -38,6 +40,10 @@ var (
 
 func main() {
 	flag.Parse()
+	if *printVersionOnly {
+		*dry = true
+		log.SetOutput(io.Discard)
+	}
 	if *showVersion {
 		printVersion()
 		return
@@ -122,6 +128,10 @@ func main() {
 	highest.Increment(flags.Major, flags.Minor, flags.Patch, flags.Stage, flags.Env, flags.Release)
 
 	log.Printf("Creating %s", highest)
+	if *printVersionOnly {
+		fmt.Println(highest.String())
+		return
+	}
 
 	h, err := r.Head()
 	if err != nil {

--- a/man/git-tag-inc.1
+++ b/man/git-tag-inc.1
@@ -45,6 +45,9 @@ Display build information and credits.
 .B --dry
 Show the tag that would be created without creating it.
 .TP
+.B --print-version-only
+Display only the tag that would be created.
+.TP
 .B --ignore
 Ignore uncommitted files in the repository (default).
 .TP

--- a/man/git-tag-inc.md
+++ b/man/git-tag-inc.md
@@ -29,6 +29,7 @@ and `uat` are also available.
 - `--verbose` – print additional output
 - `--version` – show build information
 - `--dry` – display the tag that would be created
+- `--print-version-only` – display only the tag that would be created
 - `--ignore` – ignore uncommitted files (default)
 - `--repeating` – allow new tags to repeat the last commit hash
 - `--mode=MODE` – switch between `default` and `arraneous` naming

--- a/readme.md
+++ b/readme.md
@@ -6,10 +6,11 @@ Increments the version number and tags it. (You will need to push)
 
 ```
 ./git-tag-inc [major] [minor] [patch] [release] [alpha|beta|rc] [test|uat]
---version
+--version [--print-version-only]
 ```
 
 Use `--version` to display build information and credits.
+Use `--print-version-only` to output the next version without tagging.
 
 `--mode arraneous` switches to the legacy naming (patch becomes `release`).
 


### PR DESCRIPTION
## Summary
- allow printing just the next version via `--print-version-only`
- document new flag in README and manual

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684ed02675f4832f8f07490634c7fa49