### PR TITLE
Add numeric suffix control for version increments

### DIFF
--- a/man/git-tag-inc.md
+++ b/man/git-tag-inc.md
@@ -5,13 +5,17 @@
 
 ## Synopsis
 ```
-git-tag-inc [options] [command...]
+git-tag-inc [options] [command[<n>]...]
 ```
 
 ## Description
 `git-tag-inc` detects the highest semantic version tag in the repository and
 creates the next tag. Commands control which part of the version is bumped and
-which stage or environment counters are updated.
+which stage or environment counters are updated. Commands may include an
+optional numeric suffix (for example `test5`, `rc02`, `major3`) to set the next
+counter explicitly. If the requested number is lower than the current value the
+command fails unless either `--allow-backwards` is supplied or
+`--skip-forwards` is used to automatically bump the patch component first.
 
 Supported stages include `alpha`, `beta` and `rc`. Environment counters `test`
 and `uat` are also available.
@@ -32,6 +36,8 @@ and `uat` are also available.
 - `--print-version-only` – display only the tag that would be created
 - `--ignore` – ignore uncommitted files (default)
 - `--repeating` – allow new tags to repeat the last commit hash
+- `--allow-backwards` – allow numeric suffixes to decrease counters
+- `--skip-forwards` – bump the patch version when a numeric suffix decreases a counter
 - `--mode=MODE` – switch between `default` and `arraneous` naming
 
 ## Examples
@@ -57,6 +63,14 @@ Perform multiple increments at once:
 
 ```bash
 $ git-tag-inc minor major test
+```
+
+Set explicit counters and handle backwards numbers:
+
+```bash
+$ git-tag-inc test5
+$ git-tag-inc --allow-backwards test2
+$ git-tag-inc --skip-forwards release2
 ```
 
 ## See also

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ Increments the version number and tags it. (You will need to push)
 # Usage
 
 ```
-./git-tag-inc [major] [minor] [patch] [release] [alpha|beta|rc] [test|uat]
+./git-tag-inc [--allow-backwards] [--skip-forwards] [major[<n>]] [minor[<n>]] [patch[<n>]] [release[<n>]] [alpha|beta|rc[<n>]] [test|uat[<n>]]
 --version [--print-version-only]
 ```
 
@@ -13,6 +13,15 @@ Use `--version` to display build information and credits.
 Use `--print-version-only` to output the next version without tagging.
 
 `--mode arraneous` switches to the legacy naming (patch becomes `release`).
+
+Numeric suffixes can be added to any command to set a specific counter. For example,
+`test5` produces `-test5`, `rc02` produces `-rc02` and `major3` moves directly to
+`v3.0.0`. When a numeric suffix would decrease a counter compared to the previous tag
+the command fails unless either `--allow-backwards` is provided or `--skip-forwards`
+is used. `--allow-backwards` applies the requested number directly, while
+`--skip-forwards` automatically bumps the patch component first so the resulting tag
+still increases. For instance, `git-tag-inc --skip-forwards test2` upgrades
+`v1.0.0-test3` to `v1.0.1-test2`.
 
 ## git-tag-inc then, one or more of:
 * `major        => v0.0.1-test1 => v1.0.0`
@@ -25,9 +34,27 @@ Use `--print-version-only` to output the next version without tagging.
 * `alpha        => v0.0.1-alpha1 => v0.0.1-alpha2`
 * `beta         => v0.0.1-beta1  => v0.0.1-beta2`
 * `rc           => v0.0.1-rc1    => v0.0.1-rc2`
+* `rc5          => v0.0.1-rc1    => v0.0.1-rc5`
+* `major4       => v0.0.1        => v4.0.0`
 
 ## Combinations work:
 * `patch test   => v0.0.1-test1 => v0.1.0-test1`
+* `patch rc2    => v0.1.0-rc4  => v0.1.1-rc2`
+
+## Preventing backwards moves:
+* `test1` (when the last tag was `test3`) errors unless `--allow-backwards` is supplied.
+* `--skip-forwards test1` turns the same command into `vX.Y.(Z+1)-test1` automatically.
+
+```bash
+$ git-tag-inc --allow-backwards test2
+# v1.0.0-test3 -> v1.0.0-test2
+$ git-tag-inc --skip-forwards test2
+# v1.0.0-test3 -> v1.0.1-test2
+$ git-tag-inc --allow-backwards major1
+# v3.0.0 -> v1.0.0
+$ git-tag-inc --skip-forwards release2
+# v1.2.3-test3.5 -> v1.2.4.2
+```
 
 ## Duplications don't:
 * `test test    => v0.0.1-test1 => v0.0.1-test2`
@@ -79,6 +106,10 @@ Creating v1.1.1
 $ git-tag-inc.exe release
 Largest: v1.1.1-test1
 Creating v1.1.1-test1.1
+
+$ git-tag-inc.exe --skip-forwards test2
+Largest: v1.1.1-test3
+Creating v1.1.2-test2
 ```
 
 ## Manual page

--- a/util.go
+++ b/util.go
@@ -1,51 +1,101 @@
 package gittaginc
 
 import (
+	"regexp"
+	"strconv"
 	"strings"
 )
 
 type CmdFlags struct {
-	Major   bool
-	Minor   bool
-	Patch   bool
-	Release bool
-	Stage   string
-	Env     string
-	Valid   bool
+	Major        bool
+	MajorValue   *int
+	Minor        bool
+	MinorValue   *int
+	Patch        bool
+	PatchValue   *int
+	Release      bool
+	ReleaseValue *int
+	Stage        string
+	StageValue   *int
+	StageDigits  int
+	Env          string
+	EnvValue     *int
+	EnvDigits    int
+	Valid        bool
 }
 
 func CommandsToFlags(args []string, mode string) CmdFlags {
 	c := CmdFlags{Valid: true}
+	re := regexp.MustCompile(`^([a-z]+)(\d+)?$`)
 	for _, f := range args {
-		switch strings.ToLower(f) {
+		lower := strings.ToLower(f)
+		m := re.FindStringSubmatch(lower)
+		if len(m) == 0 {
+			c.Valid = false
+			return c
+		}
+		name := m[1]
+		var value *int
+		if m[2] != "" {
+			v, err := strconv.Atoi(m[2])
+			if err != nil {
+				c.Valid = false
+				return c
+			}
+			value = pi(v)
+		}
+		switch name {
 		case "major":
 			c.Major = true
+			if value != nil {
+				c.MajorValue = value
+			}
 		case "minor":
 			c.Minor = true
+			if value != nil {
+				c.MinorValue = value
+			}
 		case "patch":
 			if mode == "arraneous" {
 				c.Valid = false
 				return c
 			}
 			c.Patch = true
+			if value != nil {
+				c.PatchValue = value
+			}
 		case "release":
 			if mode == "arraneous" {
 				c.Patch = true
+				if value != nil {
+					c.PatchValue = value
+				}
 			} else {
 				c.Release = true
+				if value != nil {
+					c.ReleaseValue = value
+				}
 			}
 		case "alpha", "beta", "rc":
 			if c.Stage != "" {
 				c.Valid = false
 				return c
 			}
-			c.Stage = strings.ToLower(f)
+			c.Stage = name
+			if value != nil {
+				c.StageValue = value
+				c.StageDigits = len(m[2])
+			}
 		case "test", "uat":
 			if c.Env != "" {
 				c.Valid = false
 				return c
 			}
-			c.Env = strings.ToLower(f)
+			c.Env = name
+			if value != nil {
+				c.EnvValue = value
+				c.EnvDigits = len(m[2])
+			}
 		default:
 			c.Valid = false
 			return c


### PR DESCRIPTION
## Summary
- support numeric suffixes on increment commands by tracking explicit targets in CmdFlags and Tag.Increment
- add --allow-backwards and --skip-forwards flags with logic to block or auto-bump when numbers move backwards
- document the workflow with CLI usage examples and broaden backwards-move test coverage for numeric suffix parsing

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68eee7709ad0832fa6da5feb439e041b