### PR TITLE
Add git-tag-cmp utility

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,26 @@ builds:
     ignore:
       - goos: windows
         goarch: arm
+  -
+    id: "git-tag-cmp"
+    binary: "git-tag-cmp"
+    dir: cmd/git-tag-cmp
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 6
+      - 7
+    ignore:
+      - goos: windows
+        goarch: arm
 archives:
   -
     format_overrides:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,6 +76,11 @@ nfpms:
         type: doc
         file_info:
           mode: 0644
+      - src: ./man/git-tag-cmp.1
+        dst: /usr/share/man/man1/git-tag-cmp.1
+        type: doc
+        file_info:
+          mode: 0644
 
 homebrew_casks:
   -

--- a/cmd/git-tag-cmp/main.go
+++ b/cmd/git-tag-cmp/main.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2025, Arran Ubels
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/arran4/git-tag-inc"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: git-tag-cmp <tag1><op><tag2>\n")
+		os.Exit(2)
+	}
+
+	arg := os.Args[1]
+
+	// Regular expression to extract tag1, operator, and tag2
+	re := regexp.MustCompile(`^(.+?)(<=|>=|<|>|==|!=)(.+?)$`)
+	matches := re.FindStringSubmatch(arg)
+	if len(matches) != 4 {
+		fmt.Fprintf(os.Stderr, "Invalid format. Expected <tag1><op><tag2>\n")
+		os.Exit(2)
+	}
+
+	tag1Str := strings.TrimSpace(matches[1])
+	op := matches[2]
+	tag2Str := strings.TrimSpace(matches[3])
+
+	tag1 := gittaginc.ParseTag(tag1Str)
+	if tag1 == nil {
+		fmt.Fprintf(os.Stderr, "Invalid tag: %s\n", tag1Str)
+		os.Exit(2)
+	}
+
+	tag2 := gittaginc.ParseTag(tag2Str)
+	if tag2 == nil {
+		fmt.Fprintf(os.Stderr, "Invalid tag: %s\n", tag2Str)
+		os.Exit(2)
+	}
+
+	lessThan := tag1.LessThan(tag2)
+	greaterThan := tag2.LessThan(tag1)
+	equal := !lessThan && !greaterThan
+
+	result := false
+	switch op {
+	case "<":
+		result = lessThan
+	case "<=":
+		result = lessThan || equal
+	case ">":
+		result = greaterThan
+	case ">=":
+		result = greaterThan || equal
+	case "==":
+		result = equal
+	case "!=":
+		result = !equal
+	}
+
+	fmt.Println(result)
+	if result {
+		os.Exit(0)
+	} else {
+		os.Exit(1)
+	}
+}

--- a/cmd/git-tag-cmp/main.go
+++ b/cmd/git-tag-cmp/main.go
@@ -4,11 +4,54 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
 	"github.com/arran4/git-tag-inc"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 )
+
+func findHighestVersionTag(r *git.Repository) (*gittaginc.Tag, error) {
+	iter, err := r.Tags()
+	if err != nil {
+		return nil, err
+	}
+	var highest *gittaginc.Tag
+	if err := iter.ForEach(func(ref *plumbing.Reference) error {
+		t := gittaginc.ParseTag(ref.Name().Short())
+		if t == nil {
+			return nil
+		}
+		t.Hash = ref.Hash().String()
+		if highest == nil || highest.LessThan(t) {
+			highest = t
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return highest, nil
+}
+
+func getTagFromStrOrPath(input string) *gittaginc.Tag {
+	// check if it's a file path
+	if strings.HasPrefix(input, "/") || strings.HasPrefix(input, "./") || strings.HasPrefix(input, "../") {
+		absPath, err := filepath.Abs(input)
+		if err == nil {
+			r, err := git.PlainOpen(absPath)
+			if err == nil {
+				// Get the highest tag in this repo
+				tag, _ := findHighestVersionTag(r)
+				if tag != nil {
+					return tag
+				}
+			}
+		}
+	}
+	return gittaginc.ParseTag(input)
+}
 
 func main() {
 	var input string
@@ -34,9 +77,7 @@ func main() {
 
 	// First try to parse with standard operators
 	// We need to order the operators from longest to shortest in regex
-	// OR use word boundaries where applicable to prevent partial matches like 'le' matching in 'lessthan'.
-	// Using alternating longest to shortest helps `.+?` non-greedy match.
-	re := regexp.MustCompile(`(?i)^(.+?)(less-than-or-equal|lessthanorequal|greater-than-or-equal|greaterthanorequal|less-than|lessthan|greater-than|greaterthan|not-equal|notequal|equals|equal|<=|>=|<|>|==|!=|-lt|-le|-gt|-ge|-eq|-ne|lt|le|gt|ge|eq|ne)(.+?)$`)
+	re := regexp.MustCompile(`(?i)^(.+?)(more-recent-than-or-equal|morerecentthanorequal|older-than-or-equal|olderthanorequal|less-than-or-equal|lessthanorequal|greater-than-or-equal|greaterthanorequal|more-recent-than|morerecentthan|older-than|olderthan|newer-than|newerthan|less-than|lessthan|greater-than|greaterthan|not-equal|notequal|equals|equal|<=|>=|<|>|==|!=|-lt|-le|-gt|-ge|-eq|-ne|lt|le|gt|ge|eq|ne)(.+?)$`)
 	matches := re.FindStringSubmatch(input)
 
 	var tag1Str, op, tag2Str string
@@ -58,15 +99,15 @@ func main() {
 		}
 	}
 
-	tag1 := gittaginc.ParseTag(tag1Str)
+	tag1 := getTagFromStrOrPath(tag1Str)
 	if tag1 == nil {
-		fmt.Fprintf(os.Stderr, "Invalid tag: %s\n", tag1Str)
+		fmt.Fprintf(os.Stderr, "Invalid tag or path: %s\n", tag1Str)
 		os.Exit(2)
 	}
 
-	tag2 := gittaginc.ParseTag(tag2Str)
+	tag2 := getTagFromStrOrPath(tag2Str)
 	if tag2 == nil {
-		fmt.Fprintf(os.Stderr, "Invalid tag: %s\n", tag2Str)
+		fmt.Fprintf(os.Stderr, "Invalid tag or path: %s\n", tag2Str)
 		os.Exit(2)
 	}
 
@@ -76,13 +117,13 @@ func main() {
 
 	result := false
 	switch op {
-	case "<", "-lt", "lt", "less-than", "lessthan":
+	case "<", "-lt", "lt", "less-than", "lessthan", "older-than", "olderthan":
 		result = lessThan
-	case "<=", "-le", "le", "less-than-or-equal", "lessthanorequal":
+	case "<=", "-le", "le", "less-than-or-equal", "lessthanorequal", "older-than-or-equal", "olderthanorequal":
 		result = lessThan || equal
-	case ">", "-gt", "gt", "greater-than", "greaterthan":
+	case ">", "-gt", "gt", "greater-than", "greaterthan", "newer-than", "newerthan", "more-recent-than", "morerecentthan":
 		result = greaterThan
-	case ">=", "-ge", "ge", "greater-than-or-equal", "greaterthanorequal":
+	case ">=", "-ge", "ge", "greater-than-or-equal", "greaterthanorequal", "newer-than-or-equal", "newerthanorequal", "more-recent-than-or-equal", "morerecentthanorequal":
 		result = greaterThan || equal
 	case "==", "-eq", "eq", "equal", "equals":
 		result = equal

--- a/cmd/git-tag-cmp/main.go
+++ b/cmd/git-tag-cmp/main.go
@@ -1,13 +1,8 @@
-// Copyright (c) 2025, Arran Ubels
-// All rights reserved.
-//
-// This source code is licensed under the BSD-style license found in the
-// LICENSE file in the root directory of this source tree.
-
 package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -16,24 +11,49 @@ import (
 )
 
 func main() {
-	if len(os.Args) < 2 {
-		fmt.Fprintf(os.Stderr, "Usage: git-tag-cmp <tag1><op><tag2>\n")
+	var input string
+	if len(os.Args) > 1 {
+		input = strings.Join(os.Args[1:], " ")
+	} else {
+		// Read from stdin
+		stat, _ := os.Stdin.Stat()
+		if (stat.Mode() & os.ModeCharDevice) == 0 {
+			bytes, err := io.ReadAll(os.Stdin)
+			if err == nil {
+				input = string(bytes)
+			}
+		}
+	}
+
+	input = strings.TrimSpace(input)
+
+	if input == "" {
+		fmt.Fprintf(os.Stderr, "Usage: git-tag-cmp <tag1> <op> <tag2>\n")
 		os.Exit(2)
 	}
 
-	arg := os.Args[1]
+	// First try to parse with standard operators
+	re := regexp.MustCompile(`^(.+?)(<=|>=|<|>|==|!=|-lt|-le|-gt|-ge|-eq|-ne)(.+?)$`)
+	matches := re.FindStringSubmatch(input)
 
-	// Regular expression to extract tag1, operator, and tag2
-	re := regexp.MustCompile(`^(.+?)(<=|>=|<|>|==|!=)(.+?)$`)
-	matches := re.FindStringSubmatch(arg)
-	if len(matches) != 4 {
-		fmt.Fprintf(os.Stderr, "Invalid format. Expected <tag1><op><tag2>\n")
-		os.Exit(2)
+	var tag1Str, op, tag2Str string
+
+	if len(matches) == 4 {
+		tag1Str = strings.TrimSpace(matches[1])
+		op = matches[2]
+		tag2Str = strings.TrimSpace(matches[3])
+	} else {
+		// Try parsing space separated
+		parts := strings.Fields(input)
+		if len(parts) == 3 {
+			tag1Str = parts[0]
+			op = parts[1]
+			tag2Str = parts[2]
+		} else {
+			fmt.Fprintf(os.Stderr, "Invalid format. Expected <tag1> <op> <tag2>\n")
+			os.Exit(2)
+		}
 	}
-
-	tag1Str := strings.TrimSpace(matches[1])
-	op := matches[2]
-	tag2Str := strings.TrimSpace(matches[3])
 
 	tag1 := gittaginc.ParseTag(tag1Str)
 	if tag1 == nil {
@@ -53,18 +73,21 @@ func main() {
 
 	result := false
 	switch op {
-	case "<":
+	case "<", "-lt":
 		result = lessThan
-	case "<=":
+	case "<=", "-le":
 		result = lessThan || equal
-	case ">":
+	case ">", "-gt":
 		result = greaterThan
-	case ">=":
+	case ">=", "-ge":
 		result = greaterThan || equal
-	case "==":
+	case "==", "-eq":
 		result = equal
-	case "!=":
+	case "!=", "-ne":
 		result = !equal
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown operator: %s\n", op)
+		os.Exit(2)
 	}
 
 	fmt.Println(result)

--- a/cmd/git-tag-cmp/main.go
+++ b/cmd/git-tag-cmp/main.go
@@ -33,7 +33,7 @@ func main() {
 	}
 
 	// First try to parse with standard operators
-	re := regexp.MustCompile(`^(.+?)(<=|>=|<|>|==|!=|-lt|-le|-gt|-ge|-eq|-ne)(.+?)$`)
+	re := regexp.MustCompile(`^(.+?)(<=|>=|<|>|==|!=|-lt|-le|-gt|-ge|-eq|-ne|lt|le|gt|ge|eq|ne)(.+?)$`)
 	matches := re.FindStringSubmatch(input)
 
 	var tag1Str, op, tag2Str string
@@ -73,17 +73,17 @@ func main() {
 
 	result := false
 	switch op {
-	case "<", "-lt":
+	case "<", "-lt", "lt":
 		result = lessThan
-	case "<=", "-le":
+	case "<=", "-le", "le":
 		result = lessThan || equal
-	case ">", "-gt":
+	case ">", "-gt", "gt":
 		result = greaterThan
-	case ">=", "-ge":
+	case ">=", "-ge", "ge":
 		result = greaterThan || equal
-	case "==", "-eq":
+	case "==", "-eq", "eq":
 		result = equal
-	case "!=", "-ne":
+	case "!=", "-ne", "ne":
 		result = !equal
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown operator: %s\n", op)

--- a/cmd/git-tag-cmp/main.go
+++ b/cmd/git-tag-cmp/main.go
@@ -33,21 +33,24 @@ func main() {
 	}
 
 	// First try to parse with standard operators
-	re := regexp.MustCompile(`^(.+?)(<=|>=|<|>|==|!=|-lt|-le|-gt|-ge|-eq|-ne|lt|le|gt|ge|eq|ne)(.+?)$`)
+	// We need to order the operators from longest to shortest in regex
+	// OR use word boundaries where applicable to prevent partial matches like 'le' matching in 'lessthan'.
+	// Using alternating longest to shortest helps `.+?` non-greedy match.
+	re := regexp.MustCompile(`(?i)^(.+?)(less-than-or-equal|lessthanorequal|greater-than-or-equal|greaterthanorequal|less-than|lessthan|greater-than|greaterthan|not-equal|notequal|equals|equal|<=|>=|<|>|==|!=|-lt|-le|-gt|-ge|-eq|-ne|lt|le|gt|ge|eq|ne)(.+?)$`)
 	matches := re.FindStringSubmatch(input)
 
 	var tag1Str, op, tag2Str string
 
 	if len(matches) == 4 {
 		tag1Str = strings.TrimSpace(matches[1])
-		op = matches[2]
+		op = strings.ToLower(matches[2])
 		tag2Str = strings.TrimSpace(matches[3])
 	} else {
 		// Try parsing space separated
 		parts := strings.Fields(input)
 		if len(parts) == 3 {
 			tag1Str = parts[0]
-			op = parts[1]
+			op = strings.ToLower(parts[1])
 			tag2Str = parts[2]
 		} else {
 			fmt.Fprintf(os.Stderr, "Invalid format. Expected <tag1> <op> <tag2>\n")
@@ -73,17 +76,17 @@ func main() {
 
 	result := false
 	switch op {
-	case "<", "-lt", "lt":
+	case "<", "-lt", "lt", "less-than", "lessthan":
 		result = lessThan
-	case "<=", "-le", "le":
+	case "<=", "-le", "le", "less-than-or-equal", "lessthanorequal":
 		result = lessThan || equal
-	case ">", "-gt", "gt":
+	case ">", "-gt", "gt", "greater-than", "greaterthan":
 		result = greaterThan
-	case ">=", "-ge", "ge":
+	case ">=", "-ge", "ge", "greater-than-or-equal", "greaterthanorequal":
 		result = greaterThan || equal
-	case "==", "-eq", "eq":
+	case "==", "-eq", "eq", "equal", "equals":
 		result = equal
-	case "!=", "-ne", "ne":
+	case "!=", "-ne", "ne", "not-equal", "notequal":
 		result = !equal
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown operator: %s\n", op)

--- a/cmd/git-tag-cmp/main_test.go
+++ b/cmd/git-tag-cmp/main_test.go
@@ -76,8 +76,8 @@ func TestMain(t *testing.T) {
 		{"stdin_full_word_ops", []string{}, "v1.0.0 less-than-or-equal v2.0.0", 0, "true\n"},
 
 		{"invalid_format", []string{"v1.0.0v2.0.0"}, "", 2, "Invalid format. Expected <tag1> <op> <tag2>\n"},
-		{"invalid_tag1", []string{"invalid<v1.0.0"}, "", 2, "Invalid tag: invalid\n"},
-		{"invalid_tag2", []string{"v1.0.0<invalid"}, "", 2, "Invalid tag: invalid\n"},
+		{"invalid_tag1", []string{"invalid<v1.0.0"}, "", 2, "Invalid tag or path: invalid\n"},
+		{"invalid_tag2", []string{"v1.0.0<invalid"}, "", 2, "Invalid tag or path: invalid\n"},
 	}
 
 	for _, tc := range tests {

--- a/cmd/git-tag-cmp/main_test.go
+++ b/cmd/git-tag-cmp/main_test.go
@@ -48,10 +48,18 @@ func TestMain(t *testing.T) {
 		{"bash_eq_true", []string{"v1.0.0", "-eq", "v1.0.0"}, "", 0, "true\n"},
 		{"bash_ne_true", []string{"v1.0.0", "-ne", "v2.0.0"}, "", 0, "true\n"},
 
+		{"word_lt_true", []string{"v1.0.0", "lt", "v2.0.0"}, "", 0, "true\n"},
+		{"word_le_true", []string{"v1.0.0", "le", "v2.0.0"}, "", 0, "true\n"},
+		{"word_gt_true", []string{"v2.0.0", "gt", "v1.0.0"}, "", 0, "true\n"},
+		{"word_ge_true", []string{"v2.0.0", "ge", "v1.0.0"}, "", 0, "true\n"},
+		{"word_eq_true", []string{"v1.0.0", "eq", "v1.0.0"}, "", 0, "true\n"},
+		{"word_ne_true", []string{"v1.0.0", "ne", "v2.0.0"}, "", 0, "true\n"},
+
 		{"spaced_args", []string{"v1.0.0", "<=", "v2.0.0"}, "", 0, "true\n"},
 
 		{"stdin", []string{}, "v1.0.0 < v2.0.0", 0, "true\n"},
 		{"stdin_bash_ops", []string{}, "v1.0.0 -le v2.0.0", 0, "true\n"},
+		{"stdin_word_ops", []string{}, "v1.0.0 le v2.0.0", 0, "true\n"},
 
 		{"invalid_format", []string{"v1.0.0v2.0.0"}, "", 2, "Invalid format. Expected <tag1> <op> <tag2>\n"},
 		{"invalid_tag1", []string{"invalid<v1.0.0"}, "", 2, "Invalid tag: invalid\n"},

--- a/cmd/git-tag-cmp/main_test.go
+++ b/cmd/git-tag-cmp/main_test.go
@@ -55,11 +55,25 @@ func TestMain(t *testing.T) {
 		{"word_eq_true", []string{"v1.0.0", "eq", "v1.0.0"}, "", 0, "true\n"},
 		{"word_ne_true", []string{"v1.0.0", "ne", "v2.0.0"}, "", 0, "true\n"},
 
+		{"full_word_lessthan_true", []string{"v1.0.0", "lessthan", "v2.0.0"}, "", 0, "true\n"},
+		{"full_word_less-than_true", []string{"v1.0.0", "less-than", "v2.0.0"}, "", 0, "true\n"},
+		{"full_word_lessthanorequal_true", []string{"v1.0.0", "lessthanorequal", "v2.0.0"}, "", 0, "true\n"},
+		{"full_word_less-than-or-equal_true", []string{"v1.0.0", "less-than-or-equal", "v2.0.0"}, "", 0, "true\n"},
+		{"full_word_greaterthan_true", []string{"v2.0.0", "greaterthan", "v1.0.0"}, "", 0, "true\n"},
+		{"full_word_greater-than_true", []string{"v2.0.0", "greater-than", "v1.0.0"}, "", 0, "true\n"},
+		{"full_word_greaterthanorequal_true", []string{"v2.0.0", "greaterthanorequal", "v1.0.0"}, "", 0, "true\n"},
+		{"full_word_greater-than-or-equal_true", []string{"v2.0.0", "greater-than-or-equal", "v1.0.0"}, "", 0, "true\n"},
+		{"full_word_equal_true", []string{"v1.0.0", "equal", "v1.0.0"}, "", 0, "true\n"},
+		{"full_word_equals_true", []string{"v1.0.0", "equals", "v1.0.0"}, "", 0, "true\n"},
+		{"full_word_notequal_true", []string{"v1.0.0", "notequal", "v2.0.0"}, "", 0, "true\n"},
+		{"full_word_not-equal_true", []string{"v1.0.0", "not-equal", "v2.0.0"}, "", 0, "true\n"},
+
 		{"spaced_args", []string{"v1.0.0", "<=", "v2.0.0"}, "", 0, "true\n"},
 
 		{"stdin", []string{}, "v1.0.0 < v2.0.0", 0, "true\n"},
 		{"stdin_bash_ops", []string{}, "v1.0.0 -le v2.0.0", 0, "true\n"},
 		{"stdin_word_ops", []string{}, "v1.0.0 le v2.0.0", 0, "true\n"},
+		{"stdin_full_word_ops", []string{}, "v1.0.0 less-than-or-equal v2.0.0", 0, "true\n"},
 
 		{"invalid_format", []string{"v1.0.0v2.0.0"}, "", 2, "Invalid format. Expected <tag1> <op> <tag2>\n"},
 		{"invalid_tag1", []string{"invalid<v1.0.0"}, "", 2, "Invalid tag: invalid\n"},

--- a/cmd/git-tag-cmp/main_test.go
+++ b/cmd/git-tag-cmp/main_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestMain(t *testing.T) {
+	binaryName := "git-tag-cmp"
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+	buildCmd := exec.Command("go", "build", "-o", binaryName)
+	if err := buildCmd.Run(); err != nil {
+		t.Fatalf("Failed to build binary: %v", err)
+	}
+	defer os.Remove(binaryName)
+
+	tests := []struct {
+		name     string
+		arg      string
+		expected int
+		out      string
+	}{
+		{"less_than_true", "v1.0.0<v2.0.0", 0, "true\n"},
+		{"less_than_false", "v2.0.0<v1.0.0", 1, "false\n"},
+		{"less_than_equal_true1", "v1.0.0<=v2.0.0", 0, "true\n"},
+		{"less_than_equal_true2", "v1.0.0<=v1.0.0", 0, "true\n"},
+		{"less_than_equal_false", "v2.0.0<=v1.0.0", 1, "false\n"},
+		{"greater_than_true", "v2.0.0>v1.0.0", 0, "true\n"},
+		{"greater_than_false", "v1.0.0>v2.0.0", 1, "false\n"},
+		{"greater_than_equal_true1", "v2.0.0>=v1.0.0", 0, "true\n"},
+		{"greater_than_equal_true2", "v1.0.0>=v1.0.0", 0, "true\n"},
+		{"greater_than_equal_false", "v1.0.0>=v2.0.0", 1, "false\n"},
+		{"equal_true", "v1.0.0==v1.0.0", 0, "true\n"},
+		{"equal_false", "v1.0.0==v2.0.0", 1, "false\n"},
+		{"not_equal_true", "v1.0.0!=v2.0.0", 0, "true\n"},
+		{"not_equal_false", "v1.0.0!=v1.0.0", 1, "false\n"},
+		{"invalid_format", "v1.0.0v2.0.0", 2, "Invalid format. Expected <tag1><op><tag2>\n"},
+		{"invalid_tag1", "invalid<v1.0.0", 2, "Invalid tag: invalid\n"},
+		{"invalid_tag2", "v1.0.0<invalid", 2, "Invalid tag: invalid\n"},
+		{"spaced_args", "v1.0.0 <= v2.0.0", 0, "true\n"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command("./"+binaryName, tc.arg)
+			out, err := cmd.CombinedOutput()
+			exitCode := 0
+			if err != nil {
+				if exitErr, ok := err.(*exec.ExitError); ok {
+					exitCode = exitErr.ExitCode()
+				} else {
+					t.Fatalf("Failed to run binary: %v", err)
+				}
+			}
+			if exitCode != tc.expected {
+				t.Errorf("Expected exit code %d, got %d. Output: %s", tc.expected, exitCode, out)
+			}
+			if tc.out != "" {
+				// Normalize output
+				actualOut := strings.ReplaceAll(string(out), "\r\n", "\n")
+				if !strings.HasSuffix(actualOut, tc.out) {
+					t.Errorf("Expected output %q, got %q", tc.out, actualOut)
+				}
+			}
+		})
+	}
+}

--- a/cmd/git-tag-cmp/main_test.go
+++ b/cmd/git-tag-cmp/main_test.go
@@ -21,33 +21,50 @@ func TestMain(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		arg      string
+		args     []string
+		stdin    string
 		expected int
 		out      string
 	}{
-		{"less_than_true", "v1.0.0<v2.0.0", 0, "true\n"},
-		{"less_than_false", "v2.0.0<v1.0.0", 1, "false\n"},
-		{"less_than_equal_true1", "v1.0.0<=v2.0.0", 0, "true\n"},
-		{"less_than_equal_true2", "v1.0.0<=v1.0.0", 0, "true\n"},
-		{"less_than_equal_false", "v2.0.0<=v1.0.0", 1, "false\n"},
-		{"greater_than_true", "v2.0.0>v1.0.0", 0, "true\n"},
-		{"greater_than_false", "v1.0.0>v2.0.0", 1, "false\n"},
-		{"greater_than_equal_true1", "v2.0.0>=v1.0.0", 0, "true\n"},
-		{"greater_than_equal_true2", "v1.0.0>=v1.0.0", 0, "true\n"},
-		{"greater_than_equal_false", "v1.0.0>=v2.0.0", 1, "false\n"},
-		{"equal_true", "v1.0.0==v1.0.0", 0, "true\n"},
-		{"equal_false", "v1.0.0==v2.0.0", 1, "false\n"},
-		{"not_equal_true", "v1.0.0!=v2.0.0", 0, "true\n"},
-		{"not_equal_false", "v1.0.0!=v1.0.0", 1, "false\n"},
-		{"invalid_format", "v1.0.0v2.0.0", 2, "Invalid format. Expected <tag1><op><tag2>\n"},
-		{"invalid_tag1", "invalid<v1.0.0", 2, "Invalid tag: invalid\n"},
-		{"invalid_tag2", "v1.0.0<invalid", 2, "Invalid tag: invalid\n"},
-		{"spaced_args", "v1.0.0 <= v2.0.0", 0, "true\n"},
+		{"less_than_true", []string{"v1.0.0<v2.0.0"}, "", 0, "true\n"},
+		{"less_than_false", []string{"v2.0.0<v1.0.0"}, "", 1, "false\n"},
+		{"less_than_equal_true1", []string{"v1.0.0<=v2.0.0"}, "", 0, "true\n"},
+		{"less_than_equal_true2", []string{"v1.0.0<=v1.0.0"}, "", 0, "true\n"},
+		{"less_than_equal_false", []string{"v2.0.0<=v1.0.0"}, "", 1, "false\n"},
+		{"greater_than_true", []string{"v2.0.0>v1.0.0"}, "", 0, "true\n"},
+		{"greater_than_false", []string{"v1.0.0>v2.0.0"}, "", 1, "false\n"},
+		{"greater_than_equal_true1", []string{"v2.0.0>=v1.0.0"}, "", 0, "true\n"},
+		{"greater_than_equal_true2", []string{"v1.0.0>=v1.0.0"}, "", 0, "true\n"},
+		{"greater_than_equal_false", []string{"v1.0.0>=v2.0.0"}, "", 1, "false\n"},
+		{"equal_true", []string{"v1.0.0==v1.0.0"}, "", 0, "true\n"},
+		{"equal_false", []string{"v1.0.0==v2.0.0"}, "", 1, "false\n"},
+		{"not_equal_true", []string{"v1.0.0!=v2.0.0"}, "", 0, "true\n"},
+		{"not_equal_false", []string{"v1.0.0!=v1.0.0"}, "", 1, "false\n"},
+
+		{"bash_lt_true", []string{"v1.0.0", "-lt", "v2.0.0"}, "", 0, "true\n"},
+		{"bash_le_true", []string{"v1.0.0", "-le", "v2.0.0"}, "", 0, "true\n"},
+		{"bash_gt_true", []string{"v2.0.0", "-gt", "v1.0.0"}, "", 0, "true\n"},
+		{"bash_ge_true", []string{"v2.0.0", "-ge", "v1.0.0"}, "", 0, "true\n"},
+		{"bash_eq_true", []string{"v1.0.0", "-eq", "v1.0.0"}, "", 0, "true\n"},
+		{"bash_ne_true", []string{"v1.0.0", "-ne", "v2.0.0"}, "", 0, "true\n"},
+
+		{"spaced_args", []string{"v1.0.0", "<=", "v2.0.0"}, "", 0, "true\n"},
+
+		{"stdin", []string{}, "v1.0.0 < v2.0.0", 0, "true\n"},
+		{"stdin_bash_ops", []string{}, "v1.0.0 -le v2.0.0", 0, "true\n"},
+
+		{"invalid_format", []string{"v1.0.0v2.0.0"}, "", 2, "Invalid format. Expected <tag1> <op> <tag2>\n"},
+		{"invalid_tag1", []string{"invalid<v1.0.0"}, "", 2, "Invalid tag: invalid\n"},
+		{"invalid_tag2", []string{"v1.0.0<invalid"}, "", 2, "Invalid tag: invalid\n"},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := exec.Command("./"+binaryName, tc.arg)
+			cmd := exec.Command("./"+binaryName, tc.args...)
+			if tc.stdin != "" {
+				cmd.Stdin = strings.NewReader(tc.stdin)
+			}
+
 			out, err := cmd.CombinedOutput()
 			exitCode := 0
 			if err != nil {

--- a/man/git-tag-cmp.1
+++ b/man/git-tag-cmp.1
@@ -1,0 +1,87 @@
+.nh
+.TH git-tag-cmp(1) Manual
+.SH Name
+\fBgit-tag-cmp\fR \- compare two git version tags or repositories
+
+.SH Synopsis
+.EX
+git-tag-cmp <tag1|repo1> <op> <tag2|repo2>
+git-tag-cmp "<tag1|repo1> <op> <tag2|repo2>"
+.EE
+
+.SH Description
+\fBgit-tag-cmp\fR takes two semantic version tags (or paths to git repositories) and a comparison operator and returns an exit code indicating whether the statement is true (0) or false (1), as well as printing "true" or "false" to stdout.
+
+.PP
+If a path to a git repository (starting with \fB/\fR, \fB\&./\fR, or \fB\&../\fR) is provided instead of a tag, \fBgit-tag-cmp\fR will open the repository and use its highest version tag for the comparison.
+
+.PP
+This utility parses tags strictly using the same logic and ranking as \fBgit-tag-inc(1)\fR\&.
+
+.SH Operands
+.IP \(bu 2
+\fB<tag1|repo1>\fR: A semantic version tag string (e.g. \fBv1.2.3-alpha1\fR) or a path to a git repository.
+.IP \(bu 2
+\fB<op>\fR: The comparison operator. Supports standard mathematical symbols, bash-style operators, and word equivalents. See \fBOperators\fP below.
+.IP \(bu 2
+\fB<tag2|repo2>\fR: A semantic version tag string (e.g. \fBv1.2.3-beta1\fR) or a path to a git repository.
+
+.SH Operators
+.IP \(bu 2
+\fB<\fR | \fB-lt\fR | \fBlt\fR | \fBless-than\fR | \fBlessthan\fR | \fBolder-than\fR | \fBolderthan\fR
+.IP \(bu 2
+\fB<=\fR | \fB-le\fR | \fBle\fR | \fBless-than-or-equal\fR | \fBlessthanorequal\fR | \fBolder-than-or-equal\fR | \fBolderthanorequal\fR
+.IP \(bu 2
+\fB>\fR | \fB-gt\fR | \fBgt\fR | \fBgreater-than\fR | \fBgreaterthan\fR | \fBnewer-than\fR | \fBnewerthan\fR | \fBmore-recent-than\fR | \fBmorerecentthan\fR
+.IP \(bu 2
+\fB>=\fR | \fB-ge\fR | \fBge\fR | \fBgreater-than-or-equal\fR | \fBgreaterthanorequal\fR | \fBnewer-than-or-equal\fR | \fBnewerthanorequal\fR | \fBmore-recent-than-or-equal\fR | \fBmorerecentthanorequal\fR
+.IP \(bu 2
+\fB==\fR | \fB-eq\fR | \fBeq\fR | \fBequal\fR | \fBequals\fR
+.IP \(bu 2
+\fB!=\fR | \fB-ne\fR | \fBne\fR | \fBnot-equal\fR | \fBnotequal\fR
+
+.SH Input Forms
+The tool supports multiple input forms for convenience:
+1. \fBMultiple arguments:\fP \fBgit-tag-cmp v1.0.0 lt v2.0.0\fR
+2. \fBSingle string:\fP \fBgit-tag-cmp "v1.0.0<=v2.0.0"\fR
+3. \fBStandard input (stdin):\fP \fBecho "v1.0.0 < v2.0.0" | git-tag-cmp\fR
+
+.SH Examples
+Compare two specific tags:
+
+.EX
+$ git-tag-cmp v1.2.3 <= v2.0.0
+true
+.EE
+
+.PP
+Use bash-style operators:
+
+.EX
+$ git-tag-cmp v2.0.0 -gt v1.0.0
+true
+.EE
+
+.PP
+Compare two repositories to see which is newer:
+
+.EX
+$ git-tag-cmp ../project1-old gt ../project1-new
+false
+.EE
+
+.PP
+Evaluate dynamically generated tags from a script:
+
+.EX
+if git-tag-cmp "$TAG1" newer-than "$TAG2"; then
+  echo "TAG1 is newer"
+fi
+.EE
+
+.SH See also
+\fBgit-tag-inc(1)\fR, \fBgit-tag(1)\fR
+
+.SH Author
+Arran Ubels arran@ubels.com.au
+\[la]mailto:arran@ubels.com.au\[ra]

--- a/man/git-tag-cmp.md
+++ b/man/git-tag-cmp.md
@@ -1,0 +1,72 @@
+# git-tag-cmp(1) Manual
+
+## Name
+`git-tag-cmp` - compare two git version tags or repositories
+
+## Synopsis
+```
+git-tag-cmp <tag1|repo1> <op> <tag2|repo2>
+git-tag-cmp "<tag1|repo1> <op> <tag2|repo2>"
+```
+
+## Description
+`git-tag-cmp` takes two semantic version tags (or paths to git repositories) and a comparison operator and returns an exit code indicating whether the statement is true (0) or false (1), as well as printing "true" or "false" to stdout.
+
+If a path to a git repository (starting with `/`, `./`, or `../`) is provided instead of a tag, `git-tag-cmp` will open the repository and use its highest version tag for the comparison.
+
+This utility parses tags strictly using the same logic and ranking as `git-tag-inc(1)`.
+
+## Operands
+- `<tag1|repo1>`: A semantic version tag string (e.g. `v1.2.3-alpha1`) or a path to a git repository.
+- `<op>`: The comparison operator. Supports standard mathematical symbols, bash-style operators, and word equivalents. See **Operators** below.
+- `<tag2|repo2>`: A semantic version tag string (e.g. `v1.2.3-beta1`) or a path to a git repository.
+
+## Operators
+- `<` | `-lt` | `lt` | `less-than` | `lessthan` | `older-than` | `olderthan`
+- `<=` | `-le` | `le` | `less-than-or-equal` | `lessthanorequal` | `older-than-or-equal` | `olderthanorequal`
+- `>` | `-gt` | `gt` | `greater-than` | `greaterthan` | `newer-than` | `newerthan` | `more-recent-than` | `morerecentthan`
+- `>=` | `-ge` | `ge` | `greater-than-or-equal` | `greaterthanorequal` | `newer-than-or-equal` | `newerthanorequal` | `more-recent-than-or-equal` | `morerecentthanorequal`
+- `==` | `-eq` | `eq` | `equal` | `equals`
+- `!=` | `-ne` | `ne` | `not-equal` | `notequal`
+
+## Input Forms
+The tool supports multiple input forms for convenience:
+1. **Multiple arguments:** `git-tag-cmp v1.0.0 lt v2.0.0`
+2. **Single string:** `git-tag-cmp "v1.0.0<=v2.0.0"`
+3. **Standard input (stdin):** `echo "v1.0.0 < v2.0.0" | git-tag-cmp`
+
+## Examples
+Compare two specific tags:
+
+```bash
+$ git-tag-cmp v1.2.3 <= v2.0.0
+true
+```
+
+Use bash-style operators:
+
+```bash
+$ git-tag-cmp v2.0.0 -gt v1.0.0
+true
+```
+
+Compare two repositories to see which is newer:
+
+```bash
+$ git-tag-cmp ../project1-old gt ../project1-new
+false
+```
+
+Evaluate dynamically generated tags from a script:
+
+```bash
+if git-tag-cmp "$TAG1" newer-than "$TAG2"; then
+  echo "TAG1 is newer"
+fi
+```
+
+## See also
+`git-tag-inc(1)`, `git-tag(1)`
+
+## Author
+Arran Ubels <arran@ubels.com.au>

--- a/readme.md
+++ b/readme.md
@@ -142,3 +142,17 @@ If you install `go-md2man` you can regenerate it from the Markdown source:
 ```bash
 go-md2man -in=man/git-tag-inc.md -out=man/git-tag-inc.1
 ```
+
+## git-tag-cmp
+
+You can use the included `git-tag-cmp` tool to compare tags or directories containing git repositories.
+
+```bash
+$ git-tag-cmp v1.2.3 <= v2.0.0
+true
+
+$ git-tag-cmp ../project1-old newer-than ../project1-new
+false
+```
+
+See the `man/git-tag-cmp.md` manual for the full list of supported operators.


### PR DESCRIPTION
Adds a new binary `git-tag-cmp` under `cmd/git-tag-cmp` that parses string arguments like `<tag1><op><tag2>` (e.g. `v1.3.3<=v3.1.3`) and outputs `true` or `false` to stdout while returning exit code 0 or 1 respectively. Also includes tests and updates the GoReleaser config to build the new binary.

---
*PR created automatically by Jules for task [5506477500189287145](https://jules.google.com/task/5506477500189287145) started by @arran4*