### PR TITLE
Refactor ParseTag to use procedural parsing instead of regex

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -380,7 +380,7 @@ func ParseTag(tag string) *Tag {
 			}
 		}
 		s = nextS
-		compName, padLen, valPtr, nextS = extractComponent(s) // get next component
+		compName, _, valPtr, nextS = extractComponent(s) // get next component (padLen not needed for release)
 	}
 
 	// 3. Check for release

--- a/tag.go
+++ b/tag.go
@@ -8,10 +8,8 @@ package gittaginc
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
-	"sync"
 )
 
 func ptr(i int) *int {
@@ -220,54 +218,182 @@ func (t *Tag) String() string {
 	return fmt.Sprintf("v%d.%d.%d%s", t.Major, t.Minor, t.Patch, ext)
 }
 
-var parseTagRe *regexp.Regexp
-var parseTagOnce sync.Once
-
-func getParseTagRe() *regexp.Regexp {
-	parseTagOnce.Do(func() {
-		parseTagRe = regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)(?:(?:-|\.)((?:alpha|beta|rc|next))(?:(?:-|\.?)((?:0*)(\d+))))?(?:(?:-|\.)((?:test|uat))(?:(?:-|\.?)((?:0*)(\d+))))?(?:(?:-|\.)(\d+))?$`)
-	})
-	return parseTagRe
-}
-
 func ParseTag(tag string) *Tag {
-	m := getParseTagRe().FindStringSubmatch(tag)
-	t := &Tag{}
-	if len(m) == 0 {
+	if !strings.HasPrefix(tag, "v") {
 		return nil
 	}
-	t.Major, _ = strconv.Atoi(m[1])
-	t.Minor, _ = strconv.Atoi(m[2])
-	t.Patch, _ = strconv.Atoi(m[3])
-	base := fmt.Sprintf("v%d.%d.%d", t.Major, t.Minor, t.Patch)
-	remainder := tag[len(base):]
-	if strings.Contains(remainder, ".") {
+
+	// Remove 'v' prefix
+	s := tag[1:]
+	t := &Tag{}
+
+	// Parse Major
+	dotIdx := strings.Index(s, ".")
+	if dotIdx == -1 {
+		return nil
+	}
+	majorStr := s[:dotIdx]
+	var err error
+	t.Major, err = strconv.Atoi(majorStr)
+	if err != nil {
+		return nil
+	}
+	s = s[dotIdx+1:]
+
+	// Parse Minor
+	dotIdx = strings.Index(s, ".")
+	if dotIdx == -1 {
+		return nil
+	}
+	minorStr := s[:dotIdx]
+	t.Minor, err = strconv.Atoi(minorStr)
+	if err != nil {
+		return nil
+	}
+	s = s[dotIdx+1:]
+
+	// Parse Patch
+	patchEndIdx := len(s)
+	for i, c := range s {
+		if c < '0' || c > '9' {
+			patchEndIdx = i
+			break
+		}
+	}
+	if patchEndIdx == 0 {
+		return nil
+	}
+	patchStr := s[:patchEndIdx]
+	t.Patch, err = strconv.Atoi(patchStr)
+	if err != nil {
+		return nil
+	}
+
+	s = s[patchEndIdx:]
+
+	// If nothing remains, it's just vX.Y.Z
+	if len(s) == 0 {
+		t.Mode = ModeLegacy // Default to legacy, although mode only really matters for extensions
+		return t
+	}
+
+	if strings.Contains(s, ".") {
 		t.Mode = ModeSemver
 	} else {
 		t.Mode = ModeLegacy
 	}
-	if m[4] != "" {
-		t.StageName = strings.ToLower(m[4])
-		t.StagePad = len(m[5])
-		v, _ := strconv.Atoi(m[6])
-		t.Stage = &v
-	}
-	if m[7] != "" {
-		t.Pad = len(m[8])
-		v, _ := strconv.Atoi(m[9])
-		switch strings.ToLower(m[7]) {
-		case "test":
-			t.Test = &v
-		case "uat":
-			t.Uat = &v
-		default:
-			return nil
+
+	// Helper function to extract a component and its digits
+	// Returns: componentName, padLen, value, remaining string
+	extractComponent := func(str string) (string, int, *int, string) {
+		if len(str) == 0 {
+			return "", 0, nil, ""
 		}
+
+		// MUST start with separator
+		if str[0] != '-' && str[0] != '.' {
+			return "", 0, nil, str
+		}
+
+		sub := str[1:]
+		if len(sub) == 0 {
+			return "", 0, nil, str
+		}
+
+		// Find where letters end and digits begin
+		letterEndIdx := 0
+		for i, c := range sub {
+			if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') {
+				letterEndIdx = i + 1
+			} else {
+				break
+			}
+		}
+
+		// Check for release component (just digits)
+		if letterEndIdx == 0 {
+			digitEndIdx := 0
+			for i, c := range sub {
+				if c >= '0' && c <= '9' {
+					digitEndIdx = i + 1
+				} else {
+					break
+				}
+			}
+			if digitEndIdx > 0 {
+				val, _ := strconv.Atoi(sub[:digitEndIdx])
+				return "release", 0, ptr(val), sub[digitEndIdx:]
+			}
+			return "", 0, nil, str
+		}
+
+		compName := strings.ToLower(sub[:letterEndIdx])
+		sub = sub[letterEndIdx:]
+
+		// Check for separator between word and digits (e.g. . in rc.1 or - in rc-1, or none in rc1)
+		// The regex `(?:(?:-|\.?)((?:0*)(\d+)))` means separator is optional (`-`, `.`, or empty).
+		if len(sub) > 0 && (sub[0] == '-' || sub[0] == '.') {
+			sub = sub[1:]
+		}
+
+		digitEndIdx := 0
+		for i, c := range sub {
+			if c >= '0' && c <= '9' {
+				digitEndIdx = i + 1
+			} else {
+				break
+			}
+		}
+
+		if digitEndIdx == 0 {
+			// MUST have digits! "(\d+)" requires at least 1 digit.
+			return "", 0, nil, str
+		}
+
+		digitsStr := sub[:digitEndIdx]
+		val, _ := strconv.Atoi(digitsStr)
+		padLen := len(digitsStr) // t.Pad and t.StagePad are the total length of the match for `((?:0*)(\d+))`
+
+		return compName, padLen, ptr(val), sub[digitEndIdx:]
 	}
-	if len(m) >= 11 && m[10] != "" {
-		v, _ := strconv.Atoi(m[10])
-		t.Release = &v
+
+	// 1. Check for stage
+	compName, padLen, valPtr, nextS := extractComponent(s)
+	if compName == "alpha" || compName == "beta" || compName == "rc" || compName == "next" {
+		t.StageName = compName
+		t.StagePad = padLen
+		if valPtr != nil {
+			t.Stage = valPtr
+		}
+		s = nextS
+		compName, padLen, valPtr, nextS = extractComponent(s) // get next component
 	}
+
+	// 2. Check for env
+	if compName == "test" || compName == "uat" {
+		t.Pad = padLen
+		if valPtr != nil {
+			if compName == "test" {
+				t.Test = valPtr
+			} else {
+				t.Uat = valPtr
+			}
+		}
+		s = nextS
+		compName, padLen, valPtr, nextS = extractComponent(s) // get next component
+	}
+
+	// 3. Check for release
+	if compName == "release" && valPtr != nil {
+		t.Release = valPtr
+		s = nextS
+	}
+
+	// If there's unparsed garbage left, or we failed to parse completely matching the regex, return nil
+	if len(s) > 0 {
+		return nil
+	}
+
 	return t
 }
 

--- a/tag_test.go
+++ b/tag_test.go
@@ -40,17 +40,50 @@ func TestParseTag(t *testing.T) {
 		{"v1.2.3-beta.02.test.03", &Tag{Mode: ModeSemver, Major: 1, Minor: 2, Patch: 3, StageName: "beta", Stage: new(2), StagePad: 2, Test: new(3), Pad: 2}},
 		{"v1.2.3.1", &Tag{Mode: ModeSemver, Major: 1, Minor: 2, Patch: 3, Release: new(1)}},
 		{"v1.2.3-1", &Tag{Mode: ModeLegacy, Major: 1, Minor: 2, Patch: 3, Release: new(1)}},
+
+		// Invalid formats (should return nil)
+		{"1.0.0", nil},                    // Missing 'v' prefix
+		{"v1.0", nil},                     // Missing patch version
+		{"v1.0.a", nil},                   // Invalid patch version
+		{"v1.0.0-beta", nil},              // Missing number in stage
+		{"v1.0.0-beta1-prod2", nil},       // Invalid env name
+		{"v1.0.0-beta1-test2-release", nil}, // Missing number in release
+		{"v1.0.0-1-test2", nil},           // Number without env
+		{"v1.0.0.", nil},
+
+		// Unseparated extensions (these fall into valid modes if they start with a valid prefix, e.g. beta, otherwise fail)
+		{"v1.0.0-test2-1", &Tag{Major: 1, Minor: 0, Patch: 0, Pad: 1, Test: ptr(2), Release: ptr(1), Mode: ModeLegacy}},
+		{"v1.0.0-beta1-1", &Tag{Major: 1, Minor: 0, Patch: 0, StageName: "beta", StagePad: 1, Stage: ptr(1), Release: ptr(1), Mode: ModeLegacy}},
+		{"v1.0.0-beta1-test2-1", &Tag{Major: 1, Minor: 0, Patch: 0, StageName: "beta", StagePad: 1, Stage: ptr(1), Pad: 1, Test: ptr(2), Release: ptr(1), Mode: ModeLegacy}},
+
+		// Edge cases with 0 padding
+		{"v1.0.0-rc0-test0", &Tag{Major: 1, StageName: "rc", StagePad: 1, Stage: ptr(0), Pad: 1, Test: ptr(0), Mode: ModeLegacy}},
+		{"v1.0.0-rc00-test00", &Tag{Major: 1, StageName: "rc", StagePad: 2, Stage: ptr(0), Pad: 2, Test: ptr(0), Mode: ModeLegacy}},
+
+		// Leading zero testing (len of capture group emulation)
+		{"v1.0.0-alpha005", &Tag{Major: 1, StageName: "alpha", StagePad: 3, Stage: ptr(5), Mode: ModeLegacy}},
+		{"v1.0.0-alpha0", &Tag{Major: 1, StageName: "alpha", StagePad: 1, Stage: ptr(0), Mode: ModeLegacy}},
+		{"v1.0.0-alpha00", &Tag{Major: 1, StageName: "alpha", StagePad: 2, Stage: ptr(0), Mode: ModeLegacy}},
+		{"v1.0.0-alpha10", &Tag{Major: 1, StageName: "alpha", StagePad: 2, Stage: ptr(10), Mode: ModeLegacy}},
+
+		// Additional Edge Cases
+		{"v0.0.0", &Tag{Major: 0, Minor: 0, Patch: 0, Mode: ModeLegacy}},
+		{"v10.20.30", &Tag{Major: 10, Minor: 20, Patch: 30, Mode: ModeLegacy}},
+		{"v1.0.0-test0", &Tag{Major: 1, Pad: 1, Test: ptr(0), Mode: ModeLegacy}},
+		{"v1.0.0-uat00", &Tag{Major: 1, Pad: 2, Uat: ptr(0), Mode: ModeLegacy}},
 	}
 	for _, tt := range tests {
-		got := ParseTag(tt.tag)
+		t.Run(tt.tag, func(t *testing.T) {
+			got := ParseTag(tt.tag)
 
-		if !reflect.DeepEqual(got, tt.want) {
-			if got == nil || tt.want == nil {
-				t.Errorf("ParseTag(%s) = %#v, want %#v", tt.tag, got, tt.want)
-			} else if got.String() != tt.want.String() {
-				t.Errorf("ParseTag(%s) = %s, want %s", tt.tag, got.String(), tt.want.String())
+			if !reflect.DeepEqual(got, tt.want) {
+				if got == nil || tt.want == nil {
+					t.Errorf("ParseTag(%s) = %#v, want %#v", tt.tag, got, tt.want)
+				} else if got.String() != tt.want.String() {
+					t.Errorf("ParseTag(%s) = %s, want %s", tt.tag, got.String(), tt.want.String())
+				}
 			}
-		}
+		})
 	}
 }
 


### PR DESCRIPTION
Replaces the regex parsing in `tag.go` with procedural logic and implements exhaustive tests as per the blog post instructions to prefer explicit code over dense regular expressions.

---
*PR created automatically by Jules for task [6791268257560198528](https://jules.google.com/task/6791268257560198528) started by @arran4*